### PR TITLE
Make it possible to add values over empty ones

### DIFF
--- a/OAuth/State/State.php
+++ b/OAuth/State/State.php
@@ -69,7 +69,7 @@ final class State implements StateInterface
      */
     public function add($key, $value)
     {
-        if (isset($this->values[$key])) {
+        if (isset($this->values[$key]) && !empty($this->values[$key])) {
             throw new DuplicateKeyException(sprintf('State key [%s] is already set.', $key));
         }
 

--- a/Tests/OAuth/State/StateTest.php
+++ b/Tests/OAuth/State/StateTest.php
@@ -82,6 +82,15 @@ final class StateTest extends \PHPUnit_Framework_TestCase
         $state->add('foo', 'foobar');
     }
 
+    public function testAddDuplicateKeyWhenItWasEmpty()
+    {
+        $state = new State(null);
+        self::assertSame('', $state->get('state'));
+
+        $state->add('state', 'foobar');
+        self::assertSame('foobar', $state->get('state'));
+    }
+
     public function testEncode()
     {
         $expectedParameter = $this->encodeArray(self::TEST_VALUES);
@@ -99,7 +108,7 @@ final class StateTest extends \PHPUnit_Framework_TestCase
     public function testEncodeEmptyValue()
     {
         $state = new State(null);
-        self::assertNull($state->encode());
+        self::assertSame('', $state->encode());
     }
 
     public function testSetCsrfTokenSetsProvidedToken()


### PR DESCRIPTION
By default we do a `new State(null)`, which creates an empty `state` paramter.

Now if we add a 'state' param in the url we couldn't change this in the State object anymore, because it was already an empty value, which is wrong. So allow `adding` values when the value was empty.