### PR TITLE
Bump ext-json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -106,7 +106,7 @@
         "php-http/client-common":         "^1.3",
         "php-http/message-factory":       "^1.0",
         "php-http/discovery":             "^1.0",
-        "ext-json": "^1.5"
+        "ext-json": "*"
     },
 
     "require-dev": {


### PR DESCRIPTION
In order to be compatible with PHP 7.4.

Up to PHP 7.3, ext-json used to follow its own versioning, but now it follows the PHP version number, like other extensions.